### PR TITLE
Конструктор ссылок учитывает &amp;

### DIFF
--- a/upload/system/library/url.php
+++ b/upload/system/library/url.php
@@ -54,7 +54,7 @@ class Url {
 		
 		if ($args) {
 			if (is_array($args)) {
-				$url .= '&amp;' . http_build_query($args);
+				$url .= '&amp;' . http_build_query($args, '', '&amp;');
 			} else {
 				$url .= str_replace('&', '&amp;', '&' . ltrim($args, '&'));
 			}


### PR DESCRIPTION
Если мы формируем ссылку без сео урла, например

`$this->url->link('extension/my/module', ['param1' => '1', 'param2' => '2']);`

то она будет такого вида:

`site.ru/index.php/?route=extension/my/module&amp;param1=1&param2=2`

кажется все норм, но 2й параметр разделен амперсендом - &, а должен быть разделен `&amp;`

XML, например, не пропускает символы &

ну и если посмотреть либу url.php, то там все & заменяются на &amp; но не учтен httpquerybuilder